### PR TITLE
removing observe and is_observed from ModelTrait

### DIFF
--- a/razor-chase/src/chase.rs
+++ b/razor-chase/src/chase.rs
@@ -363,12 +363,6 @@ pub trait ModelTrait: Clone + fmt::Display + ToString {
     /// [`Fact`]: ./enum.Observation.html#variant.Fact
     fn facts(&self) -> Vec<&Observation<Self::TermType>>;
 
-    /// Augments the receiver with `observation`, making `observation`true in the receiver.
-    fn observe(&mut self, observation: &Observation<Self::TermType>);
-
-    /// Returns true if `observation` is true in the receiver; otherwise, returns false.
-    fn is_observed(&self, observation: &Observation<Self::TermType>) -> bool;
-
     /// Returns a set of all witness terms in the receiver that are denoted by `element`.
     fn witness(
         &self,

--- a/razor-chase/src/chase/impl/basic.rs
+++ b/razor-chase/src/chase/impl/basic.rs
@@ -302,37 +302,8 @@ impl Model {
             })
             .collect();
     }
-}
 
-impl Clone for Model {
-    fn clone(&self) -> Self {
-        Self {
-            id: rand::random(),
-            element_index: self.element_index.clone(),
-            rewrites: self.rewrites.clone(),
-            facts: self.facts.clone(),
-            // In the `basic` implementation, a model is cloned after being processed in a
-            // chase-step, so its `equality_history` does not need to persist after cloning it.
-            equality_history: HashMap::new(),
-        }
-    }
-}
-
-impl ModelTrait for Model {
-    type TermType = WitnessTerm;
-
-    fn get_id(&self) -> u64 {
-        self.id
-    }
-
-    fn domain(&self) -> Vec<&E> {
-        self.rewrites.values().into_iter().unique().collect()
-    }
-
-    fn facts(&self) -> Vec<&Observation<Self::TermType>> {
-        self.facts.iter().sorted().into_iter().dedup().collect()
-    }
-
+    /// Augments the receiver with `observation`, making `observation`true in the receiver.
     fn observe(&mut self, observation: &Observation<WitnessTerm>) {
         match observation {
             Observation::Fact { relation, terms } => {
@@ -364,6 +335,7 @@ impl ModelTrait for Model {
         }
     }
 
+    /// Returns true if `observation` is true in the receiver; otherwise, returns false.
     fn is_observed(&self, observation: &Observation<WitnessTerm>) -> bool {
         match observation {
             Observation::Fact { relation, terms } => {
@@ -387,6 +359,36 @@ impl ModelTrait for Model {
                 left.is_some() && left == self.element(right)
             }
         }
+    }
+}
+
+impl Clone for Model {
+    fn clone(&self) -> Self {
+        Self {
+            id: rand::random(),
+            element_index: self.element_index.clone(),
+            rewrites: self.rewrites.clone(),
+            facts: self.facts.clone(),
+            // In the `basic` implementation, a model is cloned after being processed in a
+            // chase-step, so its `equality_history` does not need to persist after cloning it.
+            equality_history: HashMap::new(),
+        }
+    }
+}
+
+impl ModelTrait for Model {
+    type TermType = WitnessTerm;
+
+    fn get_id(&self) -> u64 {
+        self.id
+    }
+
+    fn domain(&self) -> Vec<&E> {
+        self.rewrites.values().into_iter().unique().collect()
+    }
+
+    fn facts(&self) -> Vec<&Observation<Self::TermType>> {
+        self.facts.iter().sorted().into_iter().dedup().collect()
     }
 
     fn witness(&self, element: &E) -> Vec<&WitnessTerm> {

--- a/razor-chase/src/chase/impl/reference.rs
+++ b/razor-chase/src/chase/impl/reference.rs
@@ -287,24 +287,9 @@ impl Model {
             }
         }
     }
-}
 
-impl ModelTrait for Model {
-    type TermType = WitnessTerm;
-
-    fn get_id(&self) -> u64 {
-        self.id
-    }
-
-    fn domain(&self) -> Vec<&Element> {
-        self.domain.iter().unique().collect()
-    }
-
-    fn facts(&self) -> Vec<&Observation<Self::TermType>> {
-        self.facts.iter().sorted().into_iter().dedup().collect()
-    }
-
-    fn observe(&mut self, observation: &Observation<Self::TermType>) {
+    /// Augments the receiver with `observation`, making `observation`true in the receiver.
+    pub fn observe(&mut self, observation: &Observation<WitnessTerm>) {
         match observation {
             Observation::Fact { relation, terms } => {
                 let terms: Vec<WitnessTerm> =
@@ -330,7 +315,8 @@ impl ModelTrait for Model {
         }
     }
 
-    fn is_observed(&self, observation: &Observation<Self::TermType>) -> bool {
+    /// Returns true if `observation` is true in the receiver; otherwise, returns false.
+    pub fn is_observed(&self, observation: &Observation<WitnessTerm>) -> bool {
         match observation {
             Observation::Fact { relation, terms } => {
                 let terms: Vec<Option<&Element>> = terms.iter().map(|t| self.element(t)).collect();
@@ -353,6 +339,22 @@ impl ModelTrait for Model {
                 left.is_some() && left == self.element(right)
             }
         }
+    }
+}
+
+impl ModelTrait for Model {
+    type TermType = WitnessTerm;
+
+    fn get_id(&self) -> u64 {
+        self.id
+    }
+
+    fn domain(&self) -> Vec<&Element> {
+        self.domain.iter().unique().collect()
+    }
+
+    fn facts(&self) -> Vec<&Observation<Self::TermType>> {
+        self.facts.iter().sorted().into_iter().dedup().collect()
     }
 
     fn witness(&self, element: &Element) -> Vec<&Self::TermType> {


### PR DESCRIPTION
observe and is_observed are implementation specific functions that does not have to be implemented by all instances of ModelTrait. Existing evaluators in basic and reference implementations can access these methods from instances of their corresponding associated type for Model