### PR TITLE
returning only owned values for ModelTrait

### DIFF
--- a/razor-chase/src/chase.rs
+++ b/razor-chase/src/chase.rs
@@ -356,24 +356,24 @@ pub trait ModelTrait: Clone + fmt::Display + ToString {
 
     /// Returns the domain of the receiver. The domain of a model consists of all elements in the
     /// model.
-    fn domain(&self) -> Vec<&<Self::TermType as WitnessTermTrait>::ElementType>;
+    fn domain(&self) -> Vec<<Self::TermType as WitnessTermTrait>::ElementType>;
 
     /// Returns the set of relational [`Fact`]s that are true in the receiver.
     ///
     /// [`Fact`]: ./enum.Observation.html#variant.Fact
-    fn facts(&self) -> Vec<&Observation<Self::TermType>>;
+    fn facts(&self) -> Vec<Observation<Self::TermType>>;
 
     /// Returns a set of all witness terms in the receiver that are denoted by `element`.
     fn witness(
         &self,
         element: &<Self::TermType as WitnessTermTrait>::ElementType,
-    ) -> Vec<&Self::TermType>;
+    ) -> Vec<Self::TermType>;
 
     /// Returns the element in the receiver that is denoted by `witness`.
     fn element(
         &self,
         witness: &Self::TermType,
-    ) -> Option<&<Self::TermType as WitnessTermTrait>::ElementType>;
+    ) -> Option<<Self::TermType as WitnessTermTrait>::ElementType>;
 }
 
 /// Is the trait for types that represents a [geometric sequent][sequent] in the

--- a/razor-chase/src/chase/bounder.rs
+++ b/razor-chase/src/chase/bounder.rs
@@ -30,7 +30,7 @@ impl BounderTrait for DomainSize {
             Observation::Fact { relation: _, terms } => {
                 let model_size = model.domain().len();
                 let terms: Vec<
-                    Option<&<<M as ModelTrait>::TermType as WitnessTermTrait>::ElementType>,
+                    Option<<<M as ModelTrait>::TermType as WitnessTermTrait>::ElementType>,
                 > = terms
                     .iter()
                     .map(|t| model.element(t))

--- a/razor-chase/src/chase/impl/basic.rs
+++ b/razor-chase/src/chase/impl/basic.rs
@@ -155,6 +155,36 @@ impl Model {
         }
     }
 
+    /// Returns references to the elements of this model.
+    fn domain_ref(&self) -> Vec<&E> {
+        self.rewrites.values().into_iter().unique().collect()
+    }
+
+    /// Returns a reference to an element witnessed by the given witness term.
+    fn element_ref(&self, witness: &WitnessTerm) -> Option<&E> {
+        match witness {
+            WitnessTerm::Elem { element } => self.domain_ref().into_iter().find(|e| e.eq(&element)),
+            WitnessTerm::Const { .. } => self.rewrites.get(witness).map(|e| e),
+            WitnessTerm::App { function, terms } => {
+                let terms: Vec<Option<&E>> = terms.iter().map(|t| self.element_ref(t)).collect();
+                if terms.iter().any(|e| e.is_none()) {
+                    None
+                } else {
+                    let terms: Vec<WitnessTerm> = terms
+                        .into_iter()
+                        .map(|e| e.unwrap().clone().into())
+                        .collect();
+                    self.rewrites
+                        .get(&WitnessTerm::App {
+                            function: (*function).clone(),
+                            terms,
+                        })
+                        .map(|e| e)
+                }
+            }
+        }
+    }
+
     /// Applies the rewrite rules in `equality_history` of the receiver to reduce an element to
     /// the representative element of the equational class to which it belongs.
     fn history(&self, element: &E) -> E {
@@ -339,7 +369,7 @@ impl Model {
     fn is_observed(&self, observation: &Observation<WitnessTerm>) -> bool {
         match observation {
             Observation::Fact { relation, terms } => {
-                let terms: Vec<Option<&E>> = terms.iter().map(|t| self.element(t)).collect();
+                let terms: Vec<Option<&E>> = terms.iter().map(|t| self.element_ref(t)).collect();
                 if terms.iter().any(|e| e.is_none()) {
                     false
                 } else {
@@ -383,44 +413,31 @@ impl ModelTrait for Model {
         self.id
     }
 
-    fn domain(&self) -> Vec<&E> {
-        self.rewrites.values().into_iter().unique().collect()
+    fn domain(&self) -> Vec<E> {
+        self.domain_ref().into_iter().cloned().collect()
     }
 
-    fn facts(&self) -> Vec<&Observation<Self::TermType>> {
-        self.facts.iter().sorted().into_iter().dedup().collect()
+    fn facts(&self) -> Vec<Observation<Self::TermType>> {
+        self.facts
+            .clone()
+            .into_iter()
+            .sorted()
+            .into_iter()
+            .dedup()
+            .collect()
     }
 
-    fn witness(&self, element: &E) -> Vec<&WitnessTerm> {
+    fn witness(&self, element: &E) -> Vec<WitnessTerm> {
         self.rewrites
             .iter()
             .filter(|(_, e)| *e == element)
             .map(|(t, _)| t)
+            .cloned()
             .collect()
     }
 
-    fn element(&self, witness: &WitnessTerm) -> Option<&E> {
-        match witness {
-            WitnessTerm::Elem { element } => self.domain().into_iter().find(|e| e.eq(&element)),
-            WitnessTerm::Const { .. } => self.rewrites.get(witness).map(|e| e),
-            WitnessTerm::App { function, terms } => {
-                let terms: Vec<Option<&E>> = terms.iter().map(|t| self.element(t)).collect();
-                if terms.iter().any(|e| e.is_none()) {
-                    None
-                } else {
-                    let terms: Vec<WitnessTerm> = terms
-                        .into_iter()
-                        .map(|e| e.unwrap().clone().into())
-                        .collect();
-                    self.rewrites
-                        .get(&WitnessTerm::App {
-                            function: (*function).clone(),
-                            terms,
-                        })
-                        .map(|e| e)
-                }
-            }
-        }
+    fn element(&self, witness: &WitnessTerm) -> Option<E> {
+        self.element_ref(witness).cloned()
     }
 }
 
@@ -655,7 +672,7 @@ impl<'s, Stg: StrategyTrait<Item = &'s Sequent>, B: BounderTrait> EvaluatorTrait
         strategy: &mut Stg,
         bounder: Option<&B>,
     ) -> Option<EvaluateResult<Model>> {
-        let domain: Vec<&E> = initial_model.domain().clone();
+        let domain: Vec<&E> = initial_model.domain_ref().clone();
         let domain_size = domain.len();
         for sequent in strategy {
             let vars = &sequent.free_vars;
@@ -875,8 +892,8 @@ mod test_basic {
     #[test]
     fn test_empty_model() {
         let model = Model::new();
-        let empty_domain: Vec<&E> = Vec::new();
-        let empty_facts: Vec<&Observation<WitnessTerm>> = Vec::new();
+        let empty_domain: Vec<E> = Vec::new();
+        let empty_facts: Vec<Observation<WitnessTerm>> = Vec::new();
         assert_eq!(empty_domain, model.domain());
         assert_eq_sets(&empty_facts, &model.facts());
     }
@@ -899,49 +916,49 @@ mod test_basic {
         {
             let mut model = Model::new();
             model.observe(&_R_().app0());
-            assert_eq_sets(&Vec::from_iter(vec![_R_().app0()].iter()), &model.facts());
+            assert_eq_sets(
+                &Vec::from_iter(vec![_R_().app0()].into_iter()),
+                &model.facts(),
+            );
             assert!(model.is_observed(&_R_().app0()));
         }
         {
             let mut model = Model::new();
             model.observe(&_R_().app1(_c_()));
-            assert_eq_sets(&Vec::from_iter(vec![&e_0()]), &model.domain());
+            assert_eq_sets(&Vec::from_iter(vec![e_0()]), &model.domain());
             assert_eq_sets(
-                &Vec::from_iter(vec![_R_().app1(_e_0())].iter()),
+                &Vec::from_iter(vec![_R_().app1(_e_0())].into_iter()),
                 &model.facts(),
             );
             assert!(model.is_observed(&_R_().app1(_c_())));
             assert!(model.is_observed(&_R_().app1(_e_0())));
             assert!(!model.is_observed(&_R_().app1(_e_1())));
-            assert_eq_sets(&Vec::from_iter(vec![&_c_()]), &model.witness(&e_0()));
+            assert_eq_sets(&Vec::from_iter(vec![_c_()]), &model.witness(&e_0()));
         }
         {
             let mut model = Model::new();
             model.observe(&_a_().equals(_b_()));
-            assert_eq_sets(&Vec::from_iter(vec![&e_0()]), &model.domain());
-            let empty_facts: Vec<&Observation<WitnessTerm>> = Vec::new();
+            assert_eq_sets(&Vec::from_iter(vec![e_0()]), &model.domain());
+            let empty_facts: Vec<Observation<WitnessTerm>> = Vec::new();
             assert_eq_sets(&empty_facts, &model.facts());
-            assert_eq_sets(
-                &Vec::from_iter(vec![&_a_(), &_b_()]),
-                &model.witness(&e_0()),
-            );
+            assert_eq_sets(&Vec::from_iter(vec![_a_(), _b_()]), &model.witness(&e_0()));
         }
         {
             let mut model = Model::new();
             model.observe(&_a_().equals(_a_()));
-            assert_eq_sets(&Vec::from_iter(vec![&e_0()]), &model.domain());
-            let empty_facts: Vec<&Observation<WitnessTerm>> = Vec::new();
+            assert_eq_sets(&Vec::from_iter(vec![e_0()]), &model.domain());
+            let empty_facts: Vec<Observation<WitnessTerm>> = Vec::new();
             assert_eq_sets(&empty_facts, &model.facts());
-            assert_eq_sets(&Vec::from_iter(vec![&_a_()]), &model.witness(&e_0()));
+            assert_eq_sets(&Vec::from_iter(vec![_a_()]), &model.witness(&e_0()));
         }
         {
             let mut model = Model::new();
             model.observe(&_P_().app1(_a_()));
             model.observe(&_Q_().app1(_b_()));
             model.observe(&_a_().equals(_b_()));
-            assert_eq_sets(&Vec::from_iter(vec![&e_0()]), &model.domain());
+            assert_eq_sets(&Vec::from_iter(vec![e_0()]), &model.domain());
             assert_eq_sets(
-                &Vec::from_iter(vec![_P_().app1(_e_0()), _Q_().app1(_e_0())].iter()),
+                &Vec::from_iter(vec![_P_().app1(_e_0()), _Q_().app1(_e_0())].into_iter()),
                 &model.facts(),
             );
             assert!(model.is_observed(&_P_().app1(_e_0())));
@@ -950,49 +967,43 @@ mod test_basic {
             assert!(model.is_observed(&_Q_().app1(_e_0())));
             assert!(model.is_observed(&_Q_().app1(_a_())));
             assert!(model.is_observed(&_Q_().app1(_b_())));
-            assert_eq_sets(
-                &Vec::from_iter(vec![&_a_(), &_b_()]),
-                &model.witness(&e_0()),
-            );
+            assert_eq_sets(&Vec::from_iter(vec![_a_(), _b_()]), &model.witness(&e_0()));
         }
         {
             let mut model = Model::new();
             model.observe(&_R_().app1(f().app(vec![_c_()])));
-            assert_eq_sets(&Vec::from_iter(vec![&e_0(), &e_1()]), &model.domain());
+            assert_eq_sets(&Vec::from_iter(vec![e_0(), e_1()]), &model.domain());
             assert_eq_sets(
-                &Vec::from_iter(vec![_R_().app1(_e_1())].iter()),
+                &Vec::from_iter(vec![_R_().app1(_e_1())].into_iter()),
                 &model.facts(),
             );
             assert!(model.is_observed(&_R_().app1(_e_1())));
             assert!(model.is_observed(&_R_().app1(f().app(vec![_c_()]))));
-            assert_eq_sets(&Vec::from_iter(vec![&_c_()]), &model.witness(&e_0()));
+            assert_eq_sets(&Vec::from_iter(vec![_c_()]), &model.witness(&e_0()));
             assert_eq_sets(
-                &Vec::from_iter(vec![&f().app(vec![_e_0()])]),
+                &Vec::from_iter(vec![f().app(vec![_e_0()])]),
                 &model.witness(&e_1()),
             );
         }
         {
             let mut model = Model::new();
             model.observe(&_R_().app2(_a_(), _b_()));
-            assert_eq_sets(&Vec::from_iter(vec![&e_0(), &e_1()]), &model.domain());
+            assert_eq_sets(&Vec::from_iter(vec![e_0(), e_1()]), &model.domain());
             assert_eq_sets(
-                &Vec::from_iter(vec![_R_().app2(_e_0(), _e_1())].iter()),
+                &Vec::from_iter(vec![_R_().app2(_e_0(), _e_1())].into_iter()),
                 &model.facts(),
             );
             assert!(model.is_observed(&_R_().app2(_e_0(), _e_1())));
             assert!(!model.is_observed(&_R_().app2(_e_0(), _e_0())));
-            assert_eq_sets(&Vec::from_iter(vec![&_a_()]), &model.witness(&e_0()));
-            assert_eq_sets(&Vec::from_iter(vec![&_b_()]), &model.witness(&e_1()));
+            assert_eq_sets(&Vec::from_iter(vec![_a_()]), &model.witness(&e_0()));
+            assert_eq_sets(&Vec::from_iter(vec![_b_()]), &model.witness(&e_1()));
         }
         {
             let mut model = Model::new();
             model.observe(&_R_().app2(f().app(vec![_c_()]), g().app(vec![f().app(vec![_c_()])])));
+            assert_eq_sets(&Vec::from_iter(vec![e_0(), e_1(), e_2()]), &model.domain());
             assert_eq_sets(
-                &Vec::from_iter(vec![&e_0(), &e_1(), &e_2()]),
-                &model.domain(),
-            );
-            assert_eq_sets(
-                &Vec::from_iter(vec![_R_().app2(_e_1(), _e_2())].iter()),
+                &Vec::from_iter(vec![_R_().app2(_e_1(), _e_2())].into_iter()),
                 &model.facts(),
             );
             assert!(model.is_observed(&_R_().app2(_e_1(), _e_2())));
@@ -1000,13 +1011,13 @@ mod test_basic {
                 &_R_().app2(f().app(vec![_c_()]), g().app(vec![f().app(vec![_c_()])]))
             ));
             assert!(model.is_observed(&_R_().app(vec![f().app(vec![_c_()]), _e_2()])));
-            assert_eq_sets(&Vec::from_iter(vec![&_c_()]), &model.witness(&e_0()));
+            assert_eq_sets(&Vec::from_iter(vec![_c_()]), &model.witness(&e_0()));
             assert_eq_sets(
-                &Vec::from_iter(vec![&f().app(vec![_e_0()])]),
+                &Vec::from_iter(vec![f().app(vec![_e_0()])]),
                 &model.witness(&e_1()),
             );
             assert_eq_sets(
-                &Vec::from_iter(vec![&g().app(vec![_e_1()])]),
+                &Vec::from_iter(vec![g().app(vec![_e_1()])]),
                 &model.witness(&e_2()),
             );
         }
@@ -1015,12 +1026,12 @@ mod test_basic {
             model.observe(&_R_().app(vec![_a_(), _b_()]));
             model.observe(&_S_().app(vec![_c_(), _d_()]));
             assert_eq_sets(
-                &Vec::from_iter(vec![&e_0(), &e_1(), &e_2(), &e_3()]),
+                &Vec::from_iter(vec![e_0(), e_1(), e_2(), e_3()]),
                 &model.domain(),
             );
             assert_eq_sets(
                 &Vec::from_iter(
-                    vec![_R_().app2(_e_0(), _e_1()), _S_().app2(_e_2(), _e_3())].iter(),
+                    vec![_R_().app2(_e_0(), _e_1()), _S_().app2(_e_2(), _e_3())].into_iter(),
                 ),
                 &model.facts(),
             );
@@ -1032,7 +1043,7 @@ mod test_basic {
             model.observe(&_R_().app(vec![g().app(vec![f().app(vec![_a_()])]), _b_()]));
             model.observe(&_S_().app(vec![_c_()]));
             assert_eq_sets(
-                &Vec::from_iter(vec![&e_0(), &e_1(), &e_2(), &e_3(), &e_4()]),
+                &Vec::from_iter(vec![e_0(), e_1(), e_2(), e_3(), e_4()]),
                 &model.domain(),
             );
             assert_eq_sets(
@@ -1043,7 +1054,7 @@ mod test_basic {
                         _S_().app1(_e_2()),
                         _R_().app2(_e_3(), _e_2()),
                     ]
-                    .iter(),
+                    .into_iter(),
                 ),
                 &model.facts(),
             );

--- a/razor-chase/src/chase/impl/batch.rs
+++ b/razor-chase/src/chase/impl/batch.rs
@@ -21,7 +21,7 @@ use crate::chase::{
         basic, reference,
         reference::{Element, WitnessTerm},
     },
-    BounderTrait, EvaluateResult, EvaluatorTrait, ModelTrait, Observation, Rel, StrategyTrait,
+    BounderTrait, EvaluateResult, EvaluatorTrait, Observation, Rel, StrategyTrait,
 };
 use itertools::{Either, Itertools};
 use razor_fol::syntax::V;
@@ -43,7 +43,7 @@ impl<'s, Stg: StrategyTrait<Item = &'s Sequent>, B: BounderTrait> EvaluatorTrait
     ) -> Option<EvaluateResult<Model>> {
         let mut result = EvaluateResult::new();
 
-        let domain: Vec<&Element> = initial_model.domain();
+        let domain: Vec<&Element> = initial_model.domain_ref();
         let domain_size = domain.len();
         for sequent in strategy {
             let vars = &sequent.free_vars;


### PR DESCRIPTION
This change gives flexibility to models to use their internal representation for facts, elements and terms can compute their interface values on the fly.